### PR TITLE
Handle overridden Transport channels.

### DIFF
--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/ssl/transport/OpenDistroSecuritySSLRequestHandler.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/ssl/transport/OpenDistroSecuritySSLRequestHandler.java
@@ -103,10 +103,14 @@ implements TransportRequestHandler<T> {
         }
 
         TransportChannel innerChannel = channel;
-        if("PerformanceAnalyzerTransportChannelType".equals(channel.getChannelType())) {
-            Class patc = channel.getClass();
-            Method getInnerChannel = patc.getMethod("getInnerChannel", null);
-            innerChannel = (TransportChannel) getInnerChannel.invoke(channel);
+        if (!"netty".equals(channel.getChannelType()) && !"direct".equals(channel.getChannelType())) { //netty4
+            try {
+                Class wrappedChannelCls = channel.getClass();
+                Method getInnerChannel = wrappedChannelCls.getMethod("getInnerChannel", null);
+                innerChannel = (TransportChannel) getInnerChannel.invoke(channel);
+            } catch (NoSuchMethodException ex) {
+                throw new RuntimeException("Unknown channel type " + channel.getChannelType() + "does not implement getInnerChannel method".);
+            }
         }
  
         if (!"netty".equals(channel.getChannelType())) { //netty4

--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/ssl/transport/OpenDistroSecuritySSLRequestHandler.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/ssl/transport/OpenDistroSecuritySSLRequestHandler.java
@@ -109,7 +109,7 @@ implements TransportRequestHandler<T> {
                 Method getInnerChannel = wrappedChannelCls.getMethod("getInnerChannel", null);
                 innerChannel = (TransportChannel) getInnerChannel.invoke(channel);
             } catch (NoSuchMethodException ex) {
-                throw new RuntimeException("Unknown channel type " + channel.getChannelType() + "does not implement getInnerChannel method".);
+                throw new RuntimeException("Unknown channel type " + channel.getChannelType() + " does not implement getInnerChannel method.");
             }
         }
  


### PR DESCRIPTION
Description of changes:

The security plugin assumes that transport channel is always of a particular type. The performance analyzer plugin wraps the transportChannel into a different object and this breaks the transport plugin. This change retrieves the underlying transportChannel via reflection.