### PR TITLE
bump plugin to support ES v6.8.6

### DIFF
--- a/plugin-descriptor.properties
+++ b/plugin-descriptor.properties
@@ -3,7 +3,7 @@
 description=Provides SSL for Elasticsearch 6
 #
 # 'version': plugin's version
-version=0.10.0.4
+version=0.10.1.0
 #
 # 'name': the plugin name
 name=opendistro_security-ssl
@@ -22,4 +22,4 @@ java.version=1.8
 # elasticsearch release. This version is checked when the plugin
 # is loaded so Elasticsearch will refuse to start in the presence of
 # plugins with the incorrect elasticsearch.version.
-elasticsearch.version=6.8.1
+elasticsearch.version=6.8.6

--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,7 @@
   </parent>
 
   <artifactId>opendistro_security_ssl</artifactId>
-  <version>0.10.0.4</version>
+  <version>0.10.1.0</version>
   <packaging>jar</packaging>
   <name>Open Distro For Elasticsearch Security SSL</name>
   <description>Open Distro For Elasticsearch Security SSL</description>
@@ -55,7 +55,7 @@
   </licenses>
 
   <properties>
-    <elasticsearch.version>6.8.1</elasticsearch.version>
+    <elasticsearch.version>6.8.6</elasticsearch.version>
     <!-- deps -->
     <netty-native.version>2.0.20.Final</netty-native.version>
     <log4j.version>2.11.1</log4j.version>
@@ -65,7 +65,7 @@
     <url>https://github.com/opendistro-for-elasticsearch/security-ssl</url>
     <connection>scm:git:git@github.com:opendistro-for-elasticsearch/security-ssl.git</connection>
     <developerConnection>scm:git:git@github.com:opendistro-for-elasticsearch/security-ssl.git</developerConnection>
-    <tag>v0.10.0.4</tag>
+    <tag>v0.10.1.0</tag>
   </scm>
 
   <issueManagement>


### PR DESCRIPTION
Bump Plugin to work with ES v6.8.6

blocks https://github.com/opendistro-for-elasticsearch/security/pull/190