### PR TITLE
Opendistro 0.10 Use inner channel when current channel is not netty or direct

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,5 +29,21 @@ jobs:
       - name: Test
         run: mvn test
 
-      - name: Install
+      - name: Install security-ssl
         run: mvn clean install -DskipTests
+
+      - name: Checkout security
+        uses: actions/checkout@v1
+        with:
+          repository: opendistro-for-elasticsearch/security
+          ref: opendistro-0.10
+      - name: Test and install security
+        run: mvn clean install --file ../security/pom.xml
+
+      - name: Checkout security-advanced-modules
+        uses: actions/checkout@v1
+        with:
+          repository: opendistro-for-elasticsearch/security-advanced-modules
+          ref: opendistro-0.10
+      - name: Test security-advanced-modules
+        run: mvn test --file ../security-advanced-modules/pom.xml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,24 +26,31 @@ jobs:
       - name: Checkout security-ssl
         uses: actions/checkout@v1
 
-      - name: Test and install security-ssl
-        run: mvn clean install
+      - name: Test
+        run: mvn test
+
+      - name: Install security-ssl
+        run: mvn clean install -DskipTests
 
       - name: Checkout security
         uses: actions/checkout@v1
         with:
           repository: opendistro-for-elasticsearch/security
           ref: opendistro-0.10
-      - name: Test and install security
-        run: mvn clean install --file ../security/pom.xml
+      - name: Test security
+        run: mvn test --file ../security/pom.xml
+      - name: Install security
+        run: mvn clean install -DskipTests --file ../security/pom.xml
 
       - name: Checkout security-advanced-modules
         uses: actions/checkout@v1
         with:
           repository: opendistro-for-elasticsearch/security-advanced-modules
           ref: opendistro-0.10
-      - name: Test and install security-advanced-modules
-        run: mvn clean install --file ../security-advanced-modules/pom.xml
+      - name: Test security-advanced-modules
+        run: mvn test --file ../security-advanced-modules/pom.xml
+      - name: Install security-advanced-modules
+        run: mvn clean install -DskipTests --file ../security-advanced-modules/pom.xml
 
       - name: Build artifacts
         run: mvn clean package -Padvanced -DskipTests --file ../security/pom.xml
@@ -53,3 +60,5 @@ jobs:
         with:
           name: artifacts
           path: ../security/target/releases/
+
+

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,11 +26,8 @@ jobs:
       - name: Checkout security-ssl
         uses: actions/checkout@v1
 
-      - name: Test
-        run: mvn test
-
-      - name: Install security-ssl
-        run: mvn clean install -DskipTests
+      - name: Test and install security-ssl
+        run: mvn clean install
 
       - name: Checkout security
         uses: actions/checkout@v1
@@ -45,5 +42,14 @@ jobs:
         with:
           repository: opendistro-for-elasticsearch/security-advanced-modules
           ref: opendistro-0.10
-      - name: Test security-advanced-modules
-        run: mvn test --file ../security-advanced-modules/pom.xml
+      - name: Test and install security-advanced-modules
+        run: mvn clean install --file ../security-advanced-modules/pom.xml
+
+      - name: Build artifacts
+        run: mvn clean package -Padvanced -DskipTests --file ../security/pom.xml
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v1
+        with:
+          name: artifacts
+          path: ../security/target/releases/

--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/ssl/transport/OpenDistroSecuritySSLRequestHandler.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/ssl/transport/OpenDistroSecuritySSLRequestHandler.java
@@ -101,12 +101,12 @@ implements TransportRequestHandler<T> {
             throw exception;
         }
 
-        TransportChannel innerChannel = channel;
         if (!"netty".equals(channel.getChannelType()) && !"direct".equals(channel.getChannelType())) { //netty4
             try {
                 Class wrappedChannelCls = channel.getClass();
                 Method getInnerChannel = wrappedChannelCls.getMethod("getInnerChannel", null);
-                innerChannel = (TransportChannel) getInnerChannel.invoke(channel);
+                channel = (TransportChannel) getInnerChannel.invoke(channel);
+                log.info("Using inner channel : " + channel.getChannelType());
             } catch (NoSuchMethodException ex) {
                 throw new RuntimeException("Unknown channel type " + channel.getChannelType() + " does not implement getInnerChannel method.");
             }
@@ -121,15 +121,15 @@ implements TransportRequestHandler<T> {
 
             Netty4TcpChannel nettyChannel = null;
 
-            if (innerChannel instanceof TaskTransportChannel) {
-                final TransportChannel inner = ((TaskTransportChannel) innerChannel).getChannel();
+            if (channel instanceof TaskTransportChannel) {
+                final TransportChannel inner = ((TaskTransportChannel) channel).getChannel();
                 nettyChannel = (Netty4TcpChannel) ((TcpTransportChannel) inner).getChannel();
             } else
-            if (innerChannel instanceof TcpTransportChannel) {
-                final TcpChannel inner = ((TcpTransportChannel) innerChannel).getChannel();
+            if (channel instanceof TcpTransportChannel) {
+                final TcpChannel inner = ((TcpTransportChannel) channel).getChannel();
                 nettyChannel = (Netty4TcpChannel) inner;
             } else {
-                throw new Exception("Invalid channel of type "+innerChannel.getClass()+ " ("+innerChannel.getChannelType()+")");
+                throw new Exception("Invalid channel of type " + channel.getClass() + " (" + channel.getChannelType() + ")");
             }
             
             final SslHandler sslhandler = (SslHandler) nettyChannel.getLowLevelChannel().pipeline().get("ssl_server");

--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/ssl/transport/OpenDistroSecuritySSLRequestHandler.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/ssl/transport/OpenDistroSecuritySSLRequestHandler.java
@@ -106,7 +106,7 @@ implements TransportRequestHandler<T> {
                 Class wrappedChannelCls = channel.getClass();
                 Method getInnerChannel = wrappedChannelCls.getMethod("getInnerChannel", null);
                 channel = (TransportChannel) getInnerChannel.invoke(channel);
-                log.info("Using inner channel : " + channel.getChannelType());
+                log.debug("Using inner channel : " + channel.getChannelType());
             } catch (NoSuchMethodException ex) {
                 throw new RuntimeException("Unknown channel type " + channel.getChannelType() + " does not implement getInnerChannel method.");
             }


### PR DESCRIPTION
Fix: If transport channel is not netty or direct, check if getInnerChannel is implemented using reflection and use that channel. 